### PR TITLE
Feature/availability ng

### DIFF
--- a/code/web/package.json
+++ b/code/web/package.json
@@ -28,7 +28,9 @@
     "@storybook/react": "^5.3.18",
     "babel-loader": "8.1.0",
     "dotenv-webpack": "^1.7.0",
+    "moment": "^2.29.1",
     "nodemon": "2.0.3",
+    "redux-devtools-extension": "^2.13.8",
     "webpack": "4.42.1",
     "webpack-cli": "3.3.11"
   },

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import moment from 'moment';
+
+export const Availability = () => {
+  let futureDate = moment().add(7, 'days').format('YYYY-MM-DD');
+  return (
+    <article>
+      <label htmlFor='select-availability'>
+        Select Availability:
+        <input type='date' min={Date.now()} max={futureDate}/>
+      </label>
+    </article>
+  )   
+}

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -2,12 +2,13 @@ import React from 'react';
 import moment from 'moment';
 
 export const Availability = () => {
-  let futureDate = moment().add(7, 'days').format('YYYY-MM-DD');
+  let minDate = moment().format('YYYY-MM-DD');
+  let maxDate = moment().add(7, 'days').format('YYYY-MM-DD');
   return (
     <article>
       <label htmlFor='select-availability'>
         Select Availability:
-        <input type='date' min={Date.now()} max={futureDate}/>
+        <input type='date' min={minDate} max={maxDate}/>
       </label>
     </article>
   )   

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -16,7 +16,7 @@ const Availability = (props) => {
       <article>
         <label htmlFor='select-availability'>
           Select Availability:
-          <input type='date' min={minDate} max={maxDate}/>
+          <input onChange={event => props.updateAvailability(event.target.value)} type='date' min={minDate} max={maxDate}/>
         </label>
       </article>
     </section>

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import moment from 'moment';
+import { connect } from 'react-redux';
+import { updateAvailability } from '../subscription/api/actions';
 
-export const Availability = () => {
+const Availability = (props) => {
+  //change minDate from today's date to current delivery date from BE
   let minDate = moment().format('YYYY-MM-DD');
   let maxDate = moment().add(7, 'days').format('YYYY-MM-DD');
   return (
@@ -19,3 +22,5 @@ export const Availability = () => {
     </section>
   )   
 }
+
+export default connect(null, { updateAvailability })(Availability)

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -5,11 +5,17 @@ export const Availability = () => {
   let minDate = moment().format('YYYY-MM-DD');
   let maxDate = moment().add(7, 'days').format('YYYY-MM-DD');
   return (
-    <article>
-      <label htmlFor='select-availability'>
-        Select Availability:
-        <input type='date' min={minDate} max={maxDate}/>
-      </label>
-    </article>
+    <section style={{ display: 'flex', justifyContent: 'center' }}>
+      <article style={{ paddingRight: '2em' }}>
+        <h3>Next Delivery: </h3>
+        <h4>Available?</h4>
+      </article>
+      <article>
+        <label htmlFor='select-availability'>
+          Select Availability:
+          <input type='date' min={minDate} max={maxDate}/>
+        </label>
+      </article>
+    </section>
   )   
 }

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -13,14 +13,22 @@ const Availability = (props) => {
         <h3>Next Delivery: </h3>
         <h4>Available?</h4>
       </article>
-      <article>
-        <label htmlFor='select-availability'>
-          Select Availability:
-          <input onChange={event => props.updateAvailability(event.target.value)} type='date' min={minDate} max={maxDate}/>
-        </label>
-      </article>
+      {/* refactor the following conditional render*/}
+      {props.user.isEditMode === true && 
+        (<article>
+          <label htmlFor='select-availability'>
+            Select Availability:
+            <input onChange={event => props.updateAvailability(event.target.value)} type='date' min={minDate} max={maxDate}/>
+          </label>
+        </article>)}
     </section>
   )   
 }
 
-export default connect(null, { updateAvailability })(Availability)
+function availabilityState(state) {
+    return {
+      user: state.user
+    }
+  }
+
+export default connect(availabilityState, { updateAvailability })(Availability)

--- a/code/web/src/modules/availability/Availability.js
+++ b/code/web/src/modules/availability/Availability.js
@@ -14,7 +14,7 @@ const Availability = (props) => {
         <h4>Available?</h4>
       </article>
       {/* refactor the following conditional render*/}
-      {props.user.isEditMode === true && 
+      {props.user.isEditMode && 
         (<article>
           <label htmlFor='select-availability'>
             Select Availability:

--- a/code/web/src/modules/subscription/api/actions.js
+++ b/code/web/src/modules/subscription/api/actions.js
@@ -144,7 +144,12 @@ export function remove(variables) {
 }
 
 //Update single date for availability
-export const updateAvailability = (date) => ({
-  type: 'UPDATE_AVAILABILITY',
-  date
-})
+export const updateAvailability = (date) => {
+  return dispatch => {
+    dispatch({
+      type: UPDATE_AVAILABILITY,
+      date
+    })
+  }
+}
+

--- a/code/web/src/modules/subscription/api/actions.js
+++ b/code/web/src/modules/subscription/api/actions.js
@@ -15,6 +15,7 @@ export const SUBSCRIPTIONS_GET_LIST_BY_USER_FAILURE = 'SUBSCRIPTIONS/GET_LIST_BY
 export const SUBSCRIPTIONS_GET_REQUEST = 'SUBSCRIPTIONS/GET_REQUEST'
 export const SUBSCRIPTIONS_GET_RESPONSE = 'SUBSCRIPTIONS/GET_RESPONSE'
 export const SUBSCRIPTIONS_GET_FAILURE = 'SUBSCRIPTIONS/GET_FAILURE'
+export const UPDATE_AVAILABILITY = 'SUBSCRIPTIONS/UPDATE_AVAILABILITY'
 
 // Actions
 
@@ -141,3 +142,9 @@ export function remove(variables) {
     }))
   }
 }
+
+//Update single date for availability
+export const updateAvailability = (date) => ({
+  type: 'UPDATE_AVAILABILITY',
+  date
+})

--- a/code/web/src/modules/subscription/api/state.js
+++ b/code/web/src/modules/subscription/api/state.js
@@ -59,7 +59,8 @@ export const subscriptions = (state = subscriptionsInitialState, action) => {
 const subscriptionsByUserInitialState = {
   isLoading: false,
   error: null,
-  list: []
+  list: [],
+  dateAvailable: null
 }
 
 // State

--- a/code/web/src/modules/subscription/api/state.js
+++ b/code/web/src/modules/subscription/api/state.js
@@ -11,6 +11,7 @@ import {
   SUBSCRIPTIONS_GET_REQUEST,
   SUBSCRIPTIONS_GET_RESPONSE,
   SUBSCRIPTIONS_GET_FAILURE,
+  UPDATE_AVAILABILITY
 } from './actions'
 
 // Subscriptions list
@@ -84,6 +85,13 @@ export const subscriptionsByUser = (state = subscriptionsByUserInitialState, act
         ...state,
         isLoading: false,
         error: action.error
+      }
+    
+    case UPDATE_AVAILABILITY:
+      return {
+        ...state,
+        isLoading: false,
+        dateAvailable: action.date
       }
 
     default:

--- a/code/web/src/modules/user/Profile.js
+++ b/code/web/src/modules/user/Profile.js
@@ -3,6 +3,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Helmet } from 'react-helmet'
+import { Availability } from '../availability/availability';
 import { Link } from 'react-router-dom'
 
 // UI Imports
@@ -35,7 +36,7 @@ const Profile = (props) => (
         <H4 style={{ marginBottom: '0.5em' }}>{props.user.details.name}</H4>
 
         <p style={{ color: grey2, marginBottom: '2em' }}>{props.user.details.email}</p>
-
+        <Availability />
         <Link to={userRoutes.subscriptions.path}>
           <Button theme="primary">Subscriptions</Button>
         </Link>

--- a/code/web/src/modules/user/Profile.js
+++ b/code/web/src/modules/user/Profile.js
@@ -5,9 +5,11 @@ import { connect } from 'react-redux'
 import { Helmet } from 'react-helmet'
 import Availability from '../availability/availability';
 import { Link } from 'react-router-dom'
+import { changeEditMode } from './api/actions';
+
 
 //Helper function imports
-import { determineProfileButton } from '../../setup/helpers';
+// import { determineProfileButton } from '../../setup/helpers';
 
 // UI Imports
 import { Grid, GridCell } from '../../ui/grid'
@@ -18,10 +20,18 @@ import { grey, grey2 } from '../../ui/common/colors'
 // App Imports
 import userRoutes from '../../setup/routes/user'
 import { logout } from './api/actions'
+import user from '../../setup/routes/user';
 
 // Component
-const Profile = (props) => (
-  
+const Profile = (props) => {
+  let button;
+  if (props.user.isEditMode) {
+    button = <Button onClick={() => props.changeEditMode(props.user)} theme="secondary">Save Profile</Button>
+  } else {
+    button = <Button theme="secondary">Edit Profile</Button>  
+  }
+
+  return (
   <div>
     {/* SEO */}
     <Helmet>
@@ -44,12 +54,13 @@ const Profile = (props) => (
         <Link to={userRoutes.subscriptions.path}>
           <Button theme="primary">Subscriptions</Button>
         </Link>
-        {determineProfileButton(props.user)}
+        {button}
         <Button theme="secondary" onClick={props.logout} style={{ marginLeft: '1em' }}>Logout</Button>
       </GridCell>
     </Grid>
   </div>
-)
+  )
+}
 
 // Component Properties
 Profile.propTypes = {
@@ -64,4 +75,4 @@ function profileState(state) {
   }
 }
 
-export default connect(profileState, { logout })(Profile)
+export default connect(profileState, { logout, changeEditMode })(Profile)

--- a/code/web/src/modules/user/Profile.js
+++ b/code/web/src/modules/user/Profile.js
@@ -3,8 +3,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { Helmet } from 'react-helmet'
-import { Availability } from '../availability/availability';
+import Availability from '../availability/availability';
 import { Link } from 'react-router-dom'
+
+//Helper function imports
+import { determineProfileButton } from '../../setup/helpers';
 
 // UI Imports
 import { Grid, GridCell } from '../../ui/grid'
@@ -18,6 +21,7 @@ import { logout } from './api/actions'
 
 // Component
 const Profile = (props) => (
+  
   <div>
     {/* SEO */}
     <Helmet>
@@ -40,7 +44,7 @@ const Profile = (props) => (
         <Link to={userRoutes.subscriptions.path}>
           <Button theme="primary">Subscriptions</Button>
         </Link>
-
+        {determineProfileButton(props.user)}
         <Button theme="secondary" onClick={props.logout} style={{ marginLeft: '1em' }}>Logout</Button>
       </GridCell>
     </Grid>

--- a/code/web/src/modules/user/Profile.js
+++ b/code/web/src/modules/user/Profile.js
@@ -28,7 +28,7 @@ const Profile = (props) => {
   if (props.user.isEditMode) {
     button = <Button onClick={() => props.changeEditMode(props.user)} theme="secondary">Save Profile</Button>
   } else {
-    button = <Button theme="secondary">Edit Profile</Button>  
+    button = <Button onClick={() => props.changeEditMode(props.user)} theme="secondary">Edit Profile</Button>  
   }
 
   return (

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -11,15 +11,20 @@ export const LOGIN_REQUEST = 'AUTH/LOGIN_REQUEST'
 export const LOGIN_RESPONSE = 'AUTH/LOGIN_RESPONSE'
 export const SET_USER = 'AUTH/SET_USER'
 export const LOGOUT = 'AUTH/LOGOUT'
-export const SET_EDIT_MODE = 'AUTH/SET_EDIT_MODE'
+export const CHANGE_EDIT_MODE = 'AUTH/CHANGE_EDIT_MODE'
 
 // Actions
 
 //Set edit mode for user
 
-export const setEditMode = (user) => ({
-  type: 'SET_EDIT_MODE'
-})
+export function changeEditMode(user) {
+  return dispatch => {
+    dispatch({
+      type: CHANGE_EDIT_MODE,
+      user
+    })
+  }
+}
 
 // Set a user after login or using localStorage token
 export function setUser(token, user) {

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -11,8 +11,15 @@ export const LOGIN_REQUEST = 'AUTH/LOGIN_REQUEST'
 export const LOGIN_RESPONSE = 'AUTH/LOGIN_RESPONSE'
 export const SET_USER = 'AUTH/SET_USER'
 export const LOGOUT = 'AUTH/LOGOUT'
+export const SET_EDIT_MODE = 'AUTH/SET_EDIT_MODE'
 
 // Actions
+
+//Set edit mode for user
+
+export const setEditMode = (user) => ({
+  type: 'SET_EDIT_MODE'
+})
 
 // Set a user after login or using localStorage token
 export function setUser(token, user) {

--- a/code/web/src/modules/user/api/state.js
+++ b/code/web/src/modules/user/api/state.js
@@ -1,6 +1,6 @@
 // App Imports
 import { isEmpty } from '../../../setup/helpers'
-import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT, SET_EDIT_MODE } from './actions'
+import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT, CHANGE_EDIT_MODE } from './actions'
 
 // Initial State
 export const userInitialState = {
@@ -44,12 +44,12 @@ export default (state = userInitialState, action) => {
         details: null
       }
     
-    case SET_EDIT_MODE:
+    case CHANGE_EDIT_MODE:
       return {
         ...state,
         error: null,
         isLoading: false,
-        isEditMode: true
+        isEditMode: !action.user.isEditMode
       }
 
     default:

--- a/code/web/src/modules/user/api/state.js
+++ b/code/web/src/modules/user/api/state.js
@@ -1,13 +1,14 @@
 // App Imports
 import { isEmpty } from '../../../setup/helpers'
-import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT } from './actions'
+import { SET_USER, LOGIN_REQUEST, LOGIN_RESPONSE, LOGOUT, SET_EDIT_MODE } from './actions'
 
 // Initial State
 export const userInitialState = {
   error: null,
   isLoading: false,
   isAuthenticated: false,
-  details: null
+  details: null,
+  isEditMode: true
 }
 
 // State
@@ -41,6 +42,14 @@ export default (state = userInitialState, action) => {
         isLoading: false,
         isAuthenticated: false,
         details: null
+      }
+    
+    case SET_EDIT_MODE:
+      return {
+        ...state,
+        error: null,
+        isLoading: false,
+        isEditMode: true
       }
 
     default:

--- a/code/web/src/setup/helpers.js
+++ b/code/web/src/setup/helpers.js
@@ -1,3 +1,6 @@
+import React from 'react';
+import Button from '../ui/button';
+
 // Helpers
 
 // Render element or component by provided condition
@@ -52,4 +55,12 @@ export function slug(text) {
     //.replace(/\-\-+/g, '-')         // Replace multiple - with single -
     .replace(/^-+/, '')             // Trim - from start of text
     .replace(/-+$/, '')            // Trim - from end of text
+}
+
+export function determineProfileButton(user) {
+  if (user.isEditMode) {
+    return <Button theme="secondary">Save Profile</Button>
+  } else {
+    return <Button theme="secondary">Edit Profile</Button> 
+  }
 }

--- a/code/web/src/setup/helpers.js
+++ b/code/web/src/setup/helpers.js
@@ -1,6 +1,3 @@
-import React from 'react';
-import Button from '../ui/button';
-
 // Helpers
 
 // Render element or component by provided condition
@@ -57,10 +54,4 @@ export function slug(text) {
     .replace(/-+$/, '')            // Trim - from end of text
 }
 
-export function determineProfileButton(user) {
-  if (user.isEditMode) {
-    return <Button theme="secondary">Save Profile</Button>
-  } else {
-    return <Button theme="secondary">Edit Profile</Button> 
-  }
-}
+

--- a/code/web/src/setup/store.js
+++ b/code/web/src/setup/store.js
@@ -2,6 +2,7 @@
 import { compose, combineReducers } from 'redux'
 import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
+import { composeWithDevTools } from 'redux-devtools-extension'
 
 // App Imports
 import common from '../modules/common/api/state'
@@ -40,7 +41,7 @@ export const store = createStore(
   rootReducer,
   initialState,
 
-  compose(
+  composeWithDevTools(
     applyMiddleware(thunk),
   )
 )


### PR DESCRIPTION
#### What's this PR do?

- Creates spot for showing next delivery and whether or not the user is available that day (no data retrieved yet)
- Allows user to update availability via date input within a range of 7 days
  -  currently based on today's date, but will be updated to be based on the delivery date retrieved from backend
- Implements two new action creators for Redux store 
  - `updateAvailability( )` from `code/web/src/modules/subscription/api/actions.js`
    - takes value of date input and updates the global store as `dateAvailable` on the `subscriptionsByUser` object
  - `changeEditMode( )` from `code/web/src/modules/user/api/actions.js`
    - sets `user.isEditMode` to opposite of current value with click of edit profile or save profile buttons
- Sets up `composeWithDevTools( )` so that devs can debug with Chrome extension for Redux
- Creates a new directory for `Availability`, which is then rendered in the `Profile` component

#### Where should the reviewer start?

- Start in `Availability.js` and `Profile.js`, then check out the functions imported from the `actions.js` file in both the `user/api` and `subscription/api` directories.

#### How should this be manually tested?

- This can be manually tested by starting the frontend and backend servers locally in the code editor.  When you log in as a user and click on the profile tab, you should see some text for the next delivery and a question for availability, as well as a date input field with a label of `Select Availability:`.  There should also be a `Save Profile` button.  You should be able to click on the right-most icon within that input field to select a date between today's date and 7 days in the future.  Each time you click on a date square from the input calendar, the input value should update accordingly.  When you have selected a date, click `Save Profile` and the text on that button should change to `Edit Profile`.  When this occurs, the date input field should disappear.  It should re-appear when `Edit Profile` is clicked again.

- To track these changes in the Redux store, click on the profile button and view the `diff` in Redux dev tools in the browser.  Each time that button is clicked, `user.isEditMode` should change to the inverse value (true to false, false to true, etc).  Additionally, the value of `subscriptionsByUser.dateAvailable` should initially be `null` but then updated to the selected date as user interacts with the input field calendar. 

#### Any background context you want to provide?

- We spent a lot of time figuring out how to connect the action creators to the store, and came to the conclusion that our syntax was leading to changes not being reflected in the store.  Also, we did not add much styling to the `Availability` component and plan to do so at a later time.  There are some error handling considerations for the date that include allowing the user to keep the original available date after being in edit mode.

#### What are the relevant tickets?

Closes #3 

#### Screenshots (if appropriate)

![Screen Shot 2020-12-07 at 6 41 31 PM](https://user-images.githubusercontent.com/62262404/101427321-dfd12e80-38bb-11eb-9f1a-adaef1efe9ec.png)

![Screen Shot 2020-12-07 at 6 39 57 PM](https://user-images.githubusercontent.com/62262404/101427198-abf60900-38bb-11eb-9b77-6d93733b1ead.png)

![Screen Shot 2020-12-07 at 6 40 06 PM](https://user-images.githubusercontent.com/62262404/101427205-aef0f980-38bb-11eb-8260-bca79930f56e.png)

#### Questions:

I wanted to close issue 11 but I know there is a check for testing that isn't yet complete.  Thoughts on this?

#### New Feature Submissions:
 * Have you added an explanation of what your changes do? YES
 * Have you linted your code locally prior to submission?

#### Testing:
 * Have you written new tests for your core changes, as applicable?  NOT YET
 * Have you successfully ran tests with your changes locally?  NOT YET
 * All new and existing tests passed?  Currently no test files
