### PR TITLE
Feature/connect backend

### DIFF
--- a/code/api/src/modules/subscription/mutations.js
+++ b/code/api/src/modules/subscription/mutations.js
@@ -23,7 +23,7 @@ export const subscriptionUpdate = {
   args: {
     id: {
       name: 'id',
-      type: GraphQLNonNull(GraphQLInt)
+      type: GraphQLInt
     },
     nextDeliveryDate: {
       name: 'nextDeliveryDate',

--- a/code/api/src/modules/user/mutations.js
+++ b/code/api/src/modules/user/mutations.js
@@ -33,7 +33,7 @@ export const userUpdate = {
   args: {
     id: {
       name: 'id',
-      type: GraphQLNonNull(GraphQLInt)
+      type: GraphQLInt
     },
 
     name: {

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -27,6 +27,7 @@ class ProfileForm extends Component{
 
   updateProfile = () => {
     let newState = {
+          id: this.props.user.details.id,
           image: this.state.img || this.props.user.details.img || '',
           address: this.state.address || this.props.user.details.address || '',
           email: this.state.email || this.props.user.details.email || '',

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -27,7 +27,7 @@ class ProfileForm extends Component{
 
   updateProfile = () => {
     let newState = {
-          img: this.state.img || this.props.user.details.img || '',
+          image: this.state.img || this.props.user.details.img || '',
           address: this.state.address || this.props.user.details.address || '',
           email: this.state.email || this.props.user.details.email || '',
           description: this.state.description || this.props.user.details.description || ''

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -41,7 +41,7 @@ class ProfileForm extends Component{
       id: this.props.subscriptionsByUser.list[0].id,
       nextDeliveryDate: this.props.subscriptionsByUser.nextDeliveryDate
     }
-    this.props.saveProfile(newState, newDate)
+    this.props.saveProfile(newState, newDate, this.props.subscriptionsByUser.list.map(x => x.id))
     this.props.changeEditMode(this.props.user)
   }
 

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -5,6 +5,7 @@ import Button from '../../ui/button';
 import { saveProfile } from '../user/api/actions';
 import { changeEditMode } from '../user/api/actions';
 import Availability from '../availability/Availability';
+import { getListByUser } from '../subscription/api/actions'
 
 
 // import { updateAvailability } from '../subscription/api/actions';
@@ -19,6 +20,9 @@ class ProfileForm extends Component{
         email: '',
         description: ''
       }
+  }
+  componentDidMount() {
+    this.props.getListByUser()
   }
 
   updateProfileState(e) {
@@ -97,7 +101,7 @@ class ProfileForm extends Component{
   }
 
 
-export default connect(profileFormState, { saveProfile, changeEditMode })(ProfileForm)
+export default connect(profileFormState, { getListByUser, saveProfile, changeEditMode })(ProfileForm)
 
 /*
 this.state = {

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -33,7 +33,7 @@ class ProfileForm extends Component{
           email: this.state.email || this.props.user.details.email || '',
           description: this.state.description || this.props.user.details.description || ''
         }
-    this.props.saveProfile(newState)
+    this.props.saveProfile(newState, this.props.subscriptionsByUser)
     this.props.changeEditMode(this.props.user)
   }
 

--- a/code/web/src/modules/profileForm/ProfileForm.js
+++ b/code/web/src/modules/profileForm/ProfileForm.js
@@ -33,7 +33,11 @@ class ProfileForm extends Component{
           email: this.state.email || this.props.user.details.email || '',
           description: this.state.description || this.props.user.details.description || ''
         }
-    this.props.saveProfile(newState, this.props.subscriptionsByUser)
+    let newDate = {
+      id: this.props.subscriptionsByUser.list[0].id,
+      nextDeliveryDate: this.props.subscriptionsByUser.nextDeliveryDate
+    }
+    this.props.saveProfile(newState, newDate)
     this.props.changeEditMode(this.props.user)
   }
 
@@ -87,7 +91,8 @@ class ProfileForm extends Component{
   
   function profileFormState(state) {
     return {
-      user: state.user
+      user: state.user,
+      subscriptionsByUser: state.subscriptionsByUser
     }
   }
 

--- a/code/web/src/modules/subscription/api/state.js
+++ b/code/web/src/modules/subscription/api/state.js
@@ -92,7 +92,7 @@ export const subscriptionsByUser = (state = subscriptionsByUserInitialState, act
       return {
         ...state,
         isLoading: false,
-        dateAvailable: action.date
+        nextDeliveryDate: action.date
       }
 
     default:

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -39,6 +39,19 @@ export function setUser(token, user) {
 }
 
 export function saveProfile(updatedDetails, subDetails, userSubs) {
+  if (subDetails.nextDeliveryDate) {
+    userSubs.forEach((sub) => {
+      subDetails.id = sub
+      axios.post(
+        routeApi,
+        mutation({
+          operation: "subscriptionUpdate",
+          variables: subDetails,
+          fields: ["id"],
+        })
+      );
+    });
+  }
   return (dispatch) => {
     axios.post(
       routeApi,

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -1,150 +1,175 @@
 // Imports
-import axios from 'axios'
-import { query, mutation } from 'gql-query-builder'
-import cookie from 'js-cookie'
+import axios from "axios";
+import { query, mutation } from "gql-query-builder";
+import cookie from "js-cookie";
 
 // App Imports
-import { routeApi } from '../../../setup/routes'
+import { routeApi } from "../../../setup/routes";
 
 // Actions Types
-export const LOGIN_REQUEST = 'AUTH/LOGIN_REQUEST'
-export const LOGIN_RESPONSE = 'AUTH/LOGIN_RESPONSE'
-export const SET_USER = 'AUTH/SET_USER'
-export const LOGOUT = 'AUTH/LOGOUT'
-export const CHANGE_EDIT_MODE = 'AUTH/CHANGE_EDIT_MODE'
-export const SAVE_PROFILE = 'AUTH/SAVE_PROFILE'
+export const LOGIN_REQUEST = "AUTH/LOGIN_REQUEST";
+export const LOGIN_RESPONSE = "AUTH/LOGIN_RESPONSE";
+export const SET_USER = "AUTH/SET_USER";
+export const LOGOUT = "AUTH/LOGOUT";
+export const CHANGE_EDIT_MODE = "AUTH/CHANGE_EDIT_MODE";
+export const SAVE_PROFILE = "AUTH/SAVE_PROFILE";
 
 // Actions
 
 //Set edit mode for user
 
 export function changeEditMode(user) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: CHANGE_EDIT_MODE,
-      user
-    })
-  }
+      user,
+    });
+  };
 }
 
 // Set a user after login or using localStorage token
 export function setUser(token, user) {
   if (token) {
-    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+    axios.defaults.headers.common["Authorization"] = `Bearer ${token}`;
   } else {
-    delete axios.defaults.headers.common['Authorization'];
+    delete axios.defaults.headers.common["Authorization"];
   }
 
-  return { type: SET_USER, user }
+  return { type: SET_USER, user };
 }
 
-export function saveProfile(updatedDetails) {
-  return dispatch => {
-    axios.post(routeApi, mutation({
-      operation: 'userUpdate',
-      variables: updatedDetails,
-      fields: ['id']
-    }))
+export function saveProfile(updatedDetails, subDetails, userSubs) {
+  if (subDetails.nextDeliveryDate) {
+    userSubs.forEach((sub) => {
+      subDetails.id = sub
+      axios.post(
+        routeApi,
+        mutation({
+          operation: "subscriptionUpdate",
+          variables: subDetails,
+          fields: ["id"],
+        })
+      );
+    });
+  }
+  return (dispatch) => {
+    axios.post(
+      routeApi,
+      mutation({
+        operation: "userUpdate",
+        variables: updatedDetails,
+        fields: ["id"],
+      })
+    );
     dispatch({
       type: SAVE_PROFILE,
       email: updatedDetails.email,
       img: updatedDetails.image,
       description: updatedDetails.description,
-      address: updatedDetails.address
-    })
-  }
+      address: updatedDetails.address,
+    });
+  };
 }
 
 // Login a user using credentials
 export function login(userCredentials, isLoading = true) {
-  return dispatch => {
+  return (dispatch) => {
     dispatch({
       type: LOGIN_REQUEST,
-      isLoading
-    })
+      isLoading,
+    });
 
-    return axios.post(routeApi, query({
-      operation: 'userLogin',
-      variables: userCredentials,
-      fields: ['user {name, email, role, id}', 'token']
-    }))
-      .then(response => {
-        let error = ''
+    return axios
+      .post(
+        routeApi,
+        query({
+          operation: "userLogin",
+          variables: userCredentials,
+          fields: ["user {name, email, role, id}", "token"],
+        })
+      )
+      .then((response) => {
+        let error = "";
 
         if (response.data.errors && response.data.errors.length > 0) {
-          error = response.data.errors[0].message
-        } else if (response.data.data.userLogin.token !== '') {
-          const token = response.data.data.userLogin.token
-          const user = response.data.data.userLogin.user
+          error = response.data.errors[0].message;
+        } else if (response.data.data.userLogin.token !== "") {
+          const token = response.data.data.userLogin.token;
+          const user = response.data.data.userLogin.user;
 
-          dispatch(setUser(token, user))
+          dispatch(setUser(token, user));
 
-          loginSetUserLocalStorageAndCookie(token, user)
+          loginSetUserLocalStorageAndCookie(token, user);
         }
 
         dispatch({
           type: LOGIN_RESPONSE,
-          error
-        })
+          error,
+        });
       })
-      .catch(error => {
+      .catch((error) => {
         dispatch({
           type: LOGIN_RESPONSE,
-          error: 'Please try again'
-        })
-      })
-  }
+          error: "Please try again",
+        });
+      });
+  };
 }
 
 // Set user token and info in localStorage and cookie
 export function loginSetUserLocalStorageAndCookie(token, user) {
   // Update token
-  window.localStorage.setItem('token', token)
-  window.localStorage.setItem('user', JSON.stringify(user))
+  window.localStorage.setItem("token", token);
+  window.localStorage.setItem("user", JSON.stringify(user));
 
   // Set cookie for SSR
-  cookie.set('auth', { token, user }, { path: '/' })
+  cookie.set("auth", { token, user }, { path: "/" });
 }
 
 // Register a user
 export function register(userDetails) {
-  return dispatch => {
-    return axios.post(routeApi, mutation({
-      operation: 'userSignup',
-      variables: userDetails,
-      fields: ['id', 'name', 'email']
-    }))
-  }
+  return (dispatch) => {
+    return axios.post(
+      routeApi,
+      mutation({
+        operation: "userSignup",
+        variables: userDetails,
+        fields: ["id", "name", "email"],
+      })
+    );
+  };
 }
 
 // Log out user and remove token from localStorage
 export function logout() {
-  return dispatch => {
-    logoutUnsetUserLocalStorageAndCookie()
+  return (dispatch) => {
+    logoutUnsetUserLocalStorageAndCookie();
 
     dispatch({
-      type: LOGOUT
-    })
-  }
+      type: LOGOUT,
+    });
+  };
 }
 
 // Unset user token and info in localStorage and cookie
 export function logoutUnsetUserLocalStorageAndCookie() {
   // Remove token
-  window.localStorage.removeItem('token')
-  window.localStorage.removeItem('user')
+  window.localStorage.removeItem("token");
+  window.localStorage.removeItem("user");
 
   // Remove cookie
-  cookie.remove('auth')
+  cookie.remove("auth");
 }
 
 // Get user gender
 export function getGenders() {
-  return dispatch => {
-    return axios.post(routeApi, query({
-      operation: 'userGenders',
-      fields: ['id', 'name']
-    }))
-  }
+  return (dispatch) => {
+    return axios.post(
+      routeApi,
+      query({
+        operation: "userGenders",
+        fields: ["id", "name"],
+      })
+    );
+  };
 }
- 

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -43,7 +43,7 @@ export function saveProfile(updatedDetails) {
     axios.post(routeApi, mutation({
       operation: 'userUpdate',
       variables: updatedDetails,
-      fields: ['user {email, image, description, address}']
+      fields: ['id']
     }))
     dispatch({
       type: SAVE_PROFILE,
@@ -66,7 +66,7 @@ export function login(userCredentials, isLoading = true) {
     return axios.post(routeApi, query({
       operation: 'userLogin',
       variables: userCredentials,
-      fields: ['user {name, email, role}', 'token']
+      fields: ['user {name, email, role, id}', 'token']
     }))
       .then(response => {
         let error = ''

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -39,19 +39,6 @@ export function setUser(token, user) {
 }
 
 export function saveProfile(updatedDetails, subDetails, userSubs) {
-  if (subDetails.nextDeliveryDate) {
-    userSubs.forEach((sub) => {
-      subDetails.id = sub
-      axios.post(
-        routeApi,
-        mutation({
-          operation: "subscriptionUpdate",
-          variables: subDetails,
-          fields: ["id"],
-        })
-      );
-    });
-  }
   return (dispatch) => {
     axios.post(
       routeApi,

--- a/code/web/src/modules/user/api/actions.js
+++ b/code/web/src/modules/user/api/actions.js
@@ -40,10 +40,15 @@ export function setUser(token, user) {
 
 export function saveProfile(updatedDetails) {
   return dispatch => {
+    axios.post(routeApi, mutation({
+      operation: 'userUpdate',
+      variables: updatedDetails,
+      fields: ['user {email, image, description, address}']
+    }))
     dispatch({
       type: SAVE_PROFILE,
       email: updatedDetails.email,
-      img: updatedDetails.img,
+      img: updatedDetails.image,
       description: updatedDetails.description,
       address: updatedDetails.address
     })


### PR DESCRIPTION
#### What's this PR do?

* This PR adds Axios requests to connect our FE and BE data
* When a user updates their profile, the information is now updated on the BE as well 
*  This PR adds subscription data fetching on the `componentDidMount` feature of `ProfileForm` to have the data needed to display and adjust next delivery date
* A users next delivery date is also updated only IF the user adds a date during their time editing
* The delivery date chosen will update all associated user subscriptions through iterated post requests( temporary until better solution found)

#### Where should the reviewer start?

* Start by pulling this branch down locally, and ensuring migrations and seeding is up-to-date

#### How should this be manually tested?

* Test this by running through a user story of clicking a users profile, adjusting data, and saving. The data should display on the frontend and also display in the postgres tables
* Test that all user subscription `nextDeliveryDates` change in postgres when clicking the save button
* Test that `nextDeliveryDate` only changes if a user chooses a new date
* Check out the networks tab to see detail about the graphQL interactions

#### Any background context you want to provide?

* The forEach Axios post for subscription update is by no means a great solution, but does currently update all of the users subscription delivery dates

#### What are the relevant tickets?

closes #61 
closes #62 

#### Screenshots (if appropriate)

Before:
![Screen Shot 2020-12-10 at 7 55 46 PM](https://user-images.githubusercontent.com/65369275/101847659-b4e81400-3b21-11eb-9a93-ad34240f85e5.png)
![Screen Shot 2020-12-10 at 7 56 12 PM](https://user-images.githubusercontent.com/65369275/101847676-c29d9980-3b21-11eb-85d6-d707089f9477.png)

After:
![Screen Shot 2020-12-10 at 7 58 56 PM](https://user-images.githubusercontent.com/65369275/101847842-24f69a00-3b22-11eb-9528-fc850ece49bc.png)

![Screen Shot 2020-12-10 at 8 01 01 PM](https://user-images.githubusercontent.com/65369275/101847985-7141da00-3b22-11eb-9a1c-b4de3de9b26f.png)



#### Comments:

`type: GraphQLNonNull(GraphQLInt)` on the mutations files (ex: `api/src/modules/subscription/mutations.js` ) is kicking back an error when sending a mutation request:

`"message": "Variable \"$id\" of type \"Int\" used in position expecting type \"Int!\".",`

The error no longer occurs if I switch this to the standard type: `GraphQLInt`

This change appears in this pull request

